### PR TITLE
Deprecate `ingestion_stats` explore in Looker Block + Minor changes

### DIFF
--- a/dashboards/data_ingestion_and_health.dashboard.lookml
+++ b/dashboards/data_ingestion_and_health.dashboard.lookml
@@ -5,12 +5,12 @@
   elements:
   - title: Log Type Distribution by Events Count
     name: Log Type Distribution by Events Count
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_pie
-    fields: [ingestion_stats.log_type, ingestion_stats.total_entry_number]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_entry_number]
     filters:
-      ingestion_stats.period: This Period
-    sorts: [ingestion_stats.total_entry_number desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.total_entry_number desc]
     limit: 500
     value_labels: legend
     label_type: labPer
@@ -44,19 +44,19 @@
     defaults_version: 1
     series_types: {}
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 3
     col: 0
     width: 12
     height: 6
   - title: Log Type Distribution by Throughput
     name: Log Type Distribution by Throughput
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_pie
-    fields: [ingestion_stats.log_type, ingestion_stats.total_size_bytes]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes]
     filters:
-      ingestion_stats.period: This Period
-    sorts: [ingestion_stats.total_size_bytes desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.total_size_bytes desc]
     limit: 500
     value_labels: legend
     label_type: labPer
@@ -90,19 +90,19 @@
     defaults_version: 1
     series_types: {}
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 3
     col: 12
     width: 12
     height: 6
   - title: Daily Log Information
     name: Daily Log Information
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_grid
-    fields: [ingestion_stats.log_type, ingestion_stats.timestamp_date, ingestion_stats.total_entry_number]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.timestamp_date, ingestion_metrics.total_entry_number]
     filters:
-      ingestion_stats.timestamp_time: 1 weeks
-    sorts: [ingestion_stats.timestamp_date desc]
+      ingestion_metrics.timestamp_time: 1 weeks
+    sorts: [ingestion_metrics.timestamp_date desc]
     limit: 100
     show_view_names: false
     show_row_numbers: false
@@ -135,13 +135,13 @@
     height: 6
   - title: Event Count vs Size (Last 24 hours)
     name: Event Count vs Size (Last 24 hours)
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_stats.timestamp_hour, ingestion_stats.total_entry_number, ingestion_stats.total_size_bytes_GiB]
-    fill_fields: [ingestion_stats.timestamp_hour]
+    fields: [ingestion_metrics.timestamp_hour, ingestion_metrics.total_entry_number, ingestion_metrics.total_size_bytes_GiB]
+    fill_fields: [ingestion_metrics.timestamp_hour]
     filters:
-      ingestion_stats.timestamp_time: 1 days
-    sorts: [ingestion_stats.timestamp_hour desc]
+      ingestion_metrics.timestamp_time: 1 days
+    sorts: [ingestion_metrics.timestamp_hour desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -168,19 +168,19 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_stats.count,
-            id: ingestion_stats.count, name: Ingestion Event Count}], showLabels: true,
+    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metrics.count,
+            id: ingestion_metrics.count, name: Ingestion Event Count}], showLabels: true,
         showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_stats.total_size_bytes_GiB,
-            id: ingestion_stats.total_size_bytes_GiB, name: Total Size Bytes Gib}],
+        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metrics.total_size_bytes_GiB,
+            id: ingestion_metrics.total_size_bytes_GiB, name: Total Size Bytes Gib}],
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         type: linear}]
     x_axis_label: Hours
     hidden_series: []
     series_labels:
-      ingestion_stats.count: Ingestion Event Count
-      ingestion_stats.total_size_bytes_GiB: Ingestion Throughput
-      ingestion_stats.total_entry_number: Ingested Event Count
+      ingestion_metrics.count: Ingestion Event Count
+      ingestion_metrics.total_size_bytes_GiB: Ingestion Throughput
+      ingestion_metrics.total_entry_number: Ingested Event Count
     defaults_version: 1
     listen: {}
     row: 30
@@ -189,13 +189,13 @@
     height: 6
   - title: Event Count vs Size (Last 1 week)
     name: Event Count vs Size (Last 1 week)
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_stats.timestamp_hour, ingestion_stats.total_entry_number, ingestion_stats.total_size_bytes_GiB]
-    fill_fields: [ingestion_stats.timestamp_hour]
+    fields: [ingestion_metrics.timestamp_hour, ingestion_metrics.total_entry_number, ingestion_metrics.total_size_bytes_GiB]
+    fill_fields: [ingestion_metrics.timestamp_hour]
     filters:
-      ingestion_stats.timestamp_time: 1 weeks
-    sorts: [ingestion_stats.timestamp_hour desc]
+      ingestion_metrics.timestamp_time: 1 weeks
+    sorts: [ingestion_metrics.timestamp_hour desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -222,19 +222,19 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_stats.count,
-            id: ingestion_stats.count, name: Ingestion Event Count}], showLabels: true,
+    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metrics.count,
+            id: ingestion_metrics.count, name: Ingestion Event Count}], showLabels: true,
         showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_stats.total_size_bytes_GiB,
-            id: ingestion_stats.total_size_bytes_GiB, name: Total Size Bytes Gib}],
+        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metrics.total_size_bytes_GiB,
+            id: ingestion_metrics.total_size_bytes_GiB, name: Total Size Bytes Gib}],
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         type: linear}]
     x_axis_label: Days
     hidden_series: []
     series_labels:
-      ingestion_stats.count: Ingestion Event Count
-      ingestion_stats.total_entry_number: Ingested Event Count
-      ingestion_stats.total_size_bytes_GiB: Ingestion Throughput
+      ingestion_metrics.count: Ingestion Event Count
+      ingestion_metrics.total_entry_number: Ingested Event Count
+      ingestion_metrics.total_size_bytes_GiB: Ingestion Throughput
     defaults_version: 1
     listen: {}
     row: 30
@@ -243,14 +243,14 @@
     height: 6
   - title: Event Count vs Size (Last 3 months)
     name: Event Count vs Size (Last 3 months)
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_stats.timestamp_month, ingestion_stats.total_entry_number,
-      ingestion_stats.total_size_bytes_GiB]
-    fill_fields: [ingestion_stats.timestamp_month]
+    fields: [ingestion_metrics.timestamp_month, ingestion_metrics.total_entry_number,
+      ingestion_metrics.total_size_bytes_GiB]
+    fill_fields: [ingestion_metrics.timestamp_month]
     filters:
-      ingestion_stats.timestamp_time: 3 months
-    sorts: [ingestion_stats.timestamp_month desc]
+      ingestion_metrics.timestamp_time: 3 months
+    sorts: [ingestion_metrics.timestamp_month desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -277,22 +277,22 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_stats.count,
-            id: ingestion_stats.count, name: Ingestion Event Count}], showLabels: true,
+    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metrics.count,
+            id: ingestion_metrics.count, name: Ingestion Event Count}], showLabels: true,
         showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_stats.total_size_bytes_GiB,
-            id: ingestion_stats.total_size_bytes_GiB, name: Total Size Bytes Gib}],
+        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metrics.total_size_bytes_GiB,
+            id: ingestion_metrics.total_size_bytes_GiB, name: Total Size Bytes Gib}],
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         type: linear}]
     x_axis_label: Months
     hidden_series: []
     series_colors:
-      ingestion_stats.total_entry_number: "#3EB0D5"
-      ingestion_stats.total_size_bytes_GiB: "#B1399E"
+      ingestion_metrics.total_entry_number: "#3EB0D5"
+      ingestion_metrics.total_size_bytes_GiB: "#B1399E"
     series_labels:
-      ingestion_stats.count: Ingestion Event Count
-      ingestion_stats.total_size_bytes_GiB: Ingestion Throughput
-      ingestion_stats.total_entry_number: Ingested Event Count
+      ingestion_metrics.count: Ingestion Event Count
+      ingestion_metrics.total_size_bytes_GiB: Ingestion Throughput
+      ingestion_metrics.total_entry_number: Ingested Event Count
     defaults_version: 1
     listen: {}
     row: 30
@@ -301,14 +301,14 @@
     height: 6
   - title: Total Ingest Count
     name: Total Ingest Count
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: single_value
-    fields: [ingestion_stats.total_entry_number, ingestion_stats.period]
-    sorts: [ingestion_stats.period desc]
+    fields: [ingestion_metrics.total_entry_number, ingestion_metrics.period]
+    sorts: [ingestion_metrics.period desc]
     limit: 500
     column_limit: 50
-    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_stats.total_entry_number}
-            - offset(${ingestion_stats.total_entry_number}, 1)', value_format: "#,##0,\" K\";-#,##0,\" K\"",
+    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metrics.total_entry_number}
+            - offset(${ingestion_metrics.total_entry_number}, 1)', value_format: "#,##0,\" K\";-#,##0,\" K\"",
             value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
     custom_color_enabled: true
@@ -351,20 +351,20 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 0
     col: 5
     width: 5
     height: 3
   - title: Total Error Count
     name: Total Error Count
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: single_value
-    fields: [ingestion_stats.total_error_events, ingestion_stats.period]
-    sorts: [ingestion_stats.period desc]
+    fields: [ingestion_metrics.total_error_events, ingestion_metrics.period]
+    sorts: [ingestion_metrics.period desc]
     limit: 500
-    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_stats.total_error_events}
-          - offset(${ingestion_stats.total_error_events}, 1)', value_format: "#,##0.0,\" K\";-#,##0.0,\" K\"",
+    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metrics.total_error_events}
+          - offset(${ingestion_metrics.total_error_events}, 1)', value_format: "#,##0.0,\" K\";-#,##0.0,\" K\"",
           value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
     custom_color_enabled: true
@@ -407,7 +407,7 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 0
     col: 15
     width: 5
@@ -432,10 +432,10 @@
     height: 3
   - title: Recently Ingested Events
     name: Recently Ingested Events
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_grid
-    fields: [ingestion_stats.log_type, ingestion_stats.timestamp_time]
-    sorts: [ingestion_stats.timestamp_time desc]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.timestamp_time]
+    sorts: [ingestion_metrics.timestamp_time desc]
     limit: 100
     query_timezone: America/Los_Angeles
     show_view_names: false
@@ -457,8 +457,8 @@
     show_totals: true
     show_row_totals: true
     series_labels:
-      ingestion_stats.log_type: Log Type
-      ingestion_stats.timestamp_time: Timestamp
+      ingestion_metrics.log_type: Log Type
+      ingestion_metrics.timestamp_time: Timestamp
     limit_displayed_rows_values:
       show_hide: show
       first_last: first
@@ -498,15 +498,15 @@
     height: 6
   - title: Ingestion - Events by Status
     name: Ingestion - Events by Status
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_stats.total_events, ingestion_stats.total_normalized_events,
-      ingestion_stats.total_error_events, ingestion_stats.total_parsing_error_events,
-      ingestion_stats.total_validation_error_events, ingestion_stats.timestamp_date]
-    fill_fields: [ingestion_stats.timestamp_date]
+    fields: [ingestion_metrics.total_events, ingestion_metrics.total_normalized_events,
+      ingestion_metrics.total_error_events, ingestion_metrics.total_parsing_error_events,
+      ingestion_metrics.total_validation_error_events, ingestion_metrics.timestamp_date]
+    fill_fields: [ingestion_metrics.timestamp_date]
     filters:
-      ingestion_stats.period: This Period
-    sorts: [ingestion_stats.timestamp_date desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.timestamp_date desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -535,21 +535,21 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 9
     col: 0
     width: 24
     height: 7
   - title: Ingestion - Events by Log Type
     name: Ingestion - Events by Log Type
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_grid
-    fields: [ingestion_stats.log_type, ingestion_stats.total_size_bytes, ingestion_stats.total_events,
-      ingestion_stats.total_normalized_events, ingestion_stats.total_error_events,
-      ingestion_stats.total_parsing_error_events, ingestion_stats.total_validation_error_events]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.total_events,
+      ingestion_metrics.total_normalized_events, ingestion_metrics.total_error_events,
+      ingestion_metrics.total_parsing_error_events, ingestion_metrics.total_validation_error_events]
     filters:
-      ingestion_stats.period: This Period
-    sorts: [ingestion_stats.total_size_bytes desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.total_size_bytes desc]
     limit: 100
     query_timezone: America/Los_Angeles
     show_view_names: false
@@ -571,15 +571,15 @@
     show_totals: true
     show_row_totals: true
     series_labels:
-      ingestion_stats.log_type: Log Type
-      ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_stats.total_events: Ingested Events
-      ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_stats.total_error_events: Errors
-      ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Log Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     series_cell_visualizations:
-      ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     limit_displayed_rows_values:
       show_hide: show
@@ -610,21 +610,21 @@
     defaults_version: 1
     series_types: {}
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 16
     col: 0
     width: 24
     height: 6
   - title: Ingestion - Throughput Hourly
     name: Ingestion - Throughput Hourly
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_stats.log_type, ingestion_stats.total_size_bytes, ingestion_stats.timestamp_hour]
-    pivots: [ingestion_stats.log_type]
-    fill_fields: [ingestion_stats.timestamp_hour]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.timestamp_hour]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_hour]
     filters:
-      ingestion_stats.timestamp_hour: 24 hours
-    sorts: [ingestion_stats.log_type, ingestion_stats.timestamp_hour desc]
+      ingestion_metrics.timestamp_hour: 24 hours
+    sorts: [ingestion_metrics.log_type, ingestion_metrics.timestamp_hour desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -660,40 +660,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_stats.total_size_bytes, id: GCP - ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_stats.total_size_bytes, id: UDM - ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -703,13 +703,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_stats.log_type: Data Type
-      ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_stats.total_events: Ingested Events
-      ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_stats.total_error_events: Errors
-      ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -718,7 +718,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -737,14 +737,14 @@
     height: 7
   - title: Ingestion - Throughput Weekly
     name: Ingestion - Throughput Weekly
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_stats.timestamp_week, ingestion_stats.log_type, ingestion_stats.total_size_bytes]
-    pivots: [ingestion_stats.log_type]
-    fill_fields: [ingestion_stats.timestamp_week]
+    fields: [ingestion_metrics.timestamp_week, ingestion_metrics.log_type, ingestion_metrics.total_size_bytes]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_week]
     filters:
-      ingestion_stats.timestamp_time: 7 weeks
-    sorts: [ingestion_stats.timestamp_week desc, ingestion_stats.log_type]
+      ingestion_metrics.timestamp_time: 7 weeks
+    sorts: [ingestion_metrics.timestamp_week desc, ingestion_metrics.log_type]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -780,40 +780,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_stats.total_size_bytes, id: GCP - ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_stats.total_size_bytes, id: UDM - ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -823,13 +823,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_stats.log_type: Data Type
-      ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_stats.total_events: Ingested Events
-      ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_stats.total_error_events: Errors
-      ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -838,7 +838,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -857,14 +857,14 @@
     height: 7
   - title: Ingestion - Throughput(Last 6 Months)
     name: Ingestion - Throughput(Last 6 Months)
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_stats.log_type, ingestion_stats.total_size_bytes, ingestion_stats.timestamp_month]
-    pivots: [ingestion_stats.log_type]
-    fill_fields: [ingestion_stats.timestamp_month]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.timestamp_month]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_month]
     filters:
-      ingestion_stats.timestamp_month: 6 months
-    sorts: [ingestion_stats.log_type, ingestion_stats.timestamp_month desc]
+      ingestion_metrics.timestamp_month: 6 months
+    sorts: [ingestion_metrics.log_type, ingestion_metrics.timestamp_month desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -900,40 +900,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_stats.total_size_bytes, id: GCP - ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_stats.total_size_bytes, id: UDM - ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -943,13 +943,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_stats.log_type: Data Type
-      ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_stats.total_events: Ingested Events
-      ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_stats.total_error_events: Errors
-      ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -958,7 +958,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -977,12 +977,12 @@
     height: 7
   - title: Ingestion - Throughput(All Time)
     name: Ingestion - Throughput(All Time)
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_stats.log_type, ingestion_stats.total_size_bytes, ingestion_stats.timestamp_year]
-    pivots: [ingestion_stats.log_type]
-    fill_fields: [ingestion_stats.timestamp_year]
-    sorts: [ingestion_stats.log_type, ingestion_stats.timestamp_year desc]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.timestamp_year]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_year]
+    sorts: [ingestion_metrics.log_type, ingestion_metrics.timestamp_year desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -1018,40 +1018,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_stats.total_size_bytes, id: GCP - ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_stats.total_size_bytes, id: UDM - ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -1061,13 +1061,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_stats.log_type: Data Type
-      ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_stats.total_events: Ingested Events
-      ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_stats.total_error_events: Errors
-      ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -1076,7 +1076,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -1114,6 +1114,6 @@
       type: advanced
       display: popover
       options: []
-    explore: ingestion_stats
+    explore: ingestion_metrics
     listens_to_filters: []
-    field: ingestion_stats.period_filter
+    field: ingestion_metrics.period_filter

--- a/dashboards/data_ingestion_and_health.dashboard.lookml
+++ b/dashboards/data_ingestion_and_health.dashboard.lookml
@@ -11,7 +11,7 @@
     filters:
       ingestion_metrics.period: This Period
     sorts: [ingestion_metrics.total_entry_number desc]
-    limit: 500
+    limit: 50
     value_labels: legend
     label_type: labPer
     x_axis_gridlines: false
@@ -57,7 +57,7 @@
     filters:
       ingestion_metrics.period: This Period
     sorts: [ingestion_metrics.total_size_bytes desc]
-    limit: 500
+    limit: 50
     value_labels: legend
     label_type: labPer
     x_axis_gridlines: false

--- a/dashboards/health_ingestion_metrics.dashboard.lookml
+++ b/dashboards/health_ingestion_metrics.dashboard.lookml
@@ -5,12 +5,12 @@
   elements:
   - title: Log Type Distribution by Events Count
     name: Log Type Distribution by Events Count
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_pie
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.total_entry_number]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_entry_number]
     filters:
-      ingestion_metric_with_ingestion_stats.period: This Period
-    sorts: [ingestion_metric_with_ingestion_stats.total_entry_number desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.total_entry_number desc]
     limit: 50
     value_labels: legend
     label_type: labPer
@@ -44,20 +44,20 @@
     defaults_version: 1
     series_types: {}
     listen:
-      Time: ingestion_metric_with_ingestion_stats.period_filter
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Time: ingestion_metrics.period_filter
+      Log Type: ingestion_metrics.log_type
     row: 3
     col: 0
     width: 12
     height: 6
   - title: Log Type Distribution by Throughput
     name: Log Type Distribution by Throughput
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_pie
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.total_size_bytes]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes]
     filters:
-      ingestion_metric_with_ingestion_stats.period: This Period
-    sorts: [ingestion_metric_with_ingestion_stats.total_size_bytes desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.total_size_bytes desc]
     limit: 50
     value_labels: legend
     label_type: labPer
@@ -91,20 +91,20 @@
     defaults_version: 1
     series_types: {}
     listen:
-      Time: ingestion_metric_with_ingestion_stats.period_filter
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Time: ingestion_metrics.period_filter
+      Log Type: ingestion_metrics.log_type
     row: 3
     col: 12
     width: 12
     height: 6
   - title: Daily Log Information
     name: Daily Log Information
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_grid
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.timestamp_date, ingestion_metric_with_ingestion_stats.total_entry_number]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.timestamp_date, ingestion_metrics.total_entry_number]
     filters:
-      ingestion_metric_with_ingestion_stats.timestamp_time: 1 weeks
-    sorts: [ingestion_metric_with_ingestion_stats.timestamp_date desc]
+      ingestion_metrics.timestamp_time: 1 weeks
+    sorts: [ingestion_metrics.timestamp_date desc]
     limit: 100
     show_view_names: false
     show_row_numbers: false
@@ -131,20 +131,20 @@
     series_types: {}
     defaults_version: 1
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 24
     col: 12
     width: 12
     height: 6
   - title: Event Count vs Size (Last 24 hours)
     name: Event Count vs Size (Last 24 hours)
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_metric_with_ingestion_stats.timestamp_hour, ingestion_metric_with_ingestion_stats.total_entry_number, ingestion_metric_with_ingestion_stats.total_size_bytes_GiB]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_hour]
+    fields: [ingestion_metrics.timestamp_hour, ingestion_metrics.total_entry_number, ingestion_metrics.total_size_bytes_GiB]
+    fill_fields: [ingestion_metrics.timestamp_hour]
     filters:
-      ingestion_metric_with_ingestion_stats.timestamp_time: 1 days
-    sorts: [ingestion_metric_with_ingestion_stats.timestamp_hour desc]
+      ingestion_metrics.timestamp_time: 1 days
+    sorts: [ingestion_metrics.timestamp_hour desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -171,35 +171,35 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metric_with_ingestion_stats.count,
-            id: ingestion_metric_with_ingestion_stats.count, name: Ingestion Event Count}], showLabels: true,
+    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metrics.count,
+            id: ingestion_metrics.count, name: Ingestion Event Count}], showLabels: true,
         showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metric_with_ingestion_stats.total_size_bytes_GiB,
-            id: ingestion_metric_with_ingestion_stats.total_size_bytes_GiB, name: Total Size Bytes Gib}],
+        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metrics.total_size_bytes_GiB,
+            id: ingestion_metrics.total_size_bytes_GiB, name: Total Size Bytes Gib}],
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         type: linear}]
     x_axis_label: Hours
     hidden_series: []
     series_labels:
-      ingestion_metric_with_ingestion_stats.count: Ingestion Event Count
-      ingestion_metric_with_ingestion_stats.total_size_bytes_GiB: Ingestion Throughput
-      ingestion_metric_with_ingestion_stats.total_entry_number: Ingested Event Count
+      ingestion_metrics.count: Ingestion Event Count
+      ingestion_metrics.total_size_bytes_GiB: Ingestion Throughput
+      ingestion_metrics.total_entry_number: Ingested Event Count
     defaults_version: 1
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 30
     col: 0
     width: 8
     height: 6
   - title: Event Count vs Size (Last 1 week)
     name: Event Count vs Size (Last 1 week)
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_metric_with_ingestion_stats.timestamp_hour, ingestion_metric_with_ingestion_stats.total_entry_number, ingestion_metric_with_ingestion_stats.total_size_bytes_GiB]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_hour]
+    fields: [ingestion_metrics.timestamp_hour, ingestion_metrics.total_entry_number, ingestion_metrics.total_size_bytes_GiB]
+    fill_fields: [ingestion_metrics.timestamp_hour]
     filters:
-      ingestion_metric_with_ingestion_stats.timestamp_time: 7 days
-    sorts: [ingestion_metric_with_ingestion_stats.timestamp_hour desc]
+      ingestion_metrics.timestamp_time: 7 days
+    sorts: [ingestion_metrics.timestamp_hour desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -226,36 +226,36 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metric_with_ingestion_stats.count,
-            id: ingestion_metric_with_ingestion_stats.count, name: Ingestion Event Count}], showLabels: true,
+    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metrics.count,
+            id: ingestion_metrics.count, name: Ingestion Event Count}], showLabels: true,
         showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metric_with_ingestion_stats.total_size_bytes_GiB,
-            id: ingestion_metric_with_ingestion_stats.total_size_bytes_GiB, name: Total Size Bytes Gib}],
+        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metrics.total_size_bytes_GiB,
+            id: ingestion_metrics.total_size_bytes_GiB, name: Total Size Bytes Gib}],
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         type: linear}]
     x_axis_label: Days
     hidden_series: []
     series_labels:
-      ingestion_metric_with_ingestion_stats.count: Ingestion Event Count
-      ingestion_metric_with_ingestion_stats.total_entry_number: Ingested Event Count
-      ingestion_metric_with_ingestion_stats.total_size_bytes_GiB: Ingestion Throughput
+      ingestion_metrics.count: Ingestion Event Count
+      ingestion_metrics.total_entry_number: Ingested Event Count
+      ingestion_metrics.total_size_bytes_GiB: Ingestion Throughput
     defaults_version: 1
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 30
     col: 8
     width: 8
     height: 6
   - title: Event Count vs Size (Last 3 months)
     name: Event Count vs Size (Last 3 months)
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_metric_with_ingestion_stats.timestamp_month, ingestion_metric_with_ingestion_stats.total_entry_number,
-      ingestion_metric_with_ingestion_stats.total_size_bytes_GiB]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_month]
+    fields: [ingestion_metrics.timestamp_month, ingestion_metrics.total_entry_number,
+      ingestion_metrics.total_size_bytes_GiB]
+    fill_fields: [ingestion_metrics.timestamp_month]
     filters:
-      ingestion_metric_with_ingestion_stats.timestamp_time: 3 months
-    sorts: [ingestion_metric_with_ingestion_stats.timestamp_month desc]
+      ingestion_metrics.timestamp_time: 3 months
+    sorts: [ingestion_metrics.timestamp_month desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -282,39 +282,39 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metric_with_ingestion_stats.count,
-            id: ingestion_metric_with_ingestion_stats.count, name: Ingestion Event Count}], showLabels: true,
+    y_axes: [{label: '', orientation: left, series: [{axisId: ingestion_metrics.count,
+            id: ingestion_metrics.count, name: Ingestion Event Count}], showLabels: true,
         showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metric_with_ingestion_stats.total_size_bytes_GiB,
-            id: ingestion_metric_with_ingestion_stats.total_size_bytes_GiB, name: Total Size Bytes Gib}],
+        type: linear}, {label: '', orientation: right, series: [{axisId: ingestion_metrics.total_size_bytes_GiB,
+            id: ingestion_metrics.total_size_bytes_GiB, name: Total Size Bytes Gib}],
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         type: linear}]
     x_axis_label: Months
     hidden_series: []
     series_colors:
-      ingestion_metric_with_ingestion_stats.total_entry_number: "#3EB0D5"
-      ingestion_metric_with_ingestion_stats.total_size_bytes_GiB: "#B1399E"
+      ingestion_metrics.total_entry_number: "#3EB0D5"
+      ingestion_metrics.total_size_bytes_GiB: "#B1399E"
     series_labels:
-      ingestion_metric_with_ingestion_stats.count: Ingestion Event Count
-      ingestion_metric_with_ingestion_stats.total_size_bytes_GiB: Ingestion Throughput
-      ingestion_metric_with_ingestion_stats.total_entry_number: Ingested Event Count
+      ingestion_metrics.count: Ingestion Event Count
+      ingestion_metrics.total_size_bytes_GiB: Ingestion Throughput
+      ingestion_metrics.total_entry_number: Ingested Event Count
     defaults_version: 1
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 30
     col: 16
     width: 8
     height: 6
   - title: Total Ingest Count
     name: Total Ingest Count
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: single_value
-    fields: [ingestion_metric_with_ingestion_stats.total_entry_number, ingestion_metric_with_ingestion_stats.period]
-    sorts: [ingestion_metric_with_ingestion_stats.period desc]
+    fields: [ingestion_metrics.total_entry_number, ingestion_metrics.period]
+    sorts: [ingestion_metrics.period desc]
     limit: 500
     column_limit: 50
-    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metric_with_ingestion_stats.total_entry_number}
-          - offset(${ingestion_metric_with_ingestion_stats.total_entry_number}, 1)', value_format: "#,##0,\" K\";-#,##0,\" K\"",
+    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metrics.total_entry_number}
+          - offset(${ingestion_metrics.total_entry_number}, 1)', value_format: "#,##0,\" K\";-#,##0,\" K\"",
         value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
     custom_color_enabled: true
@@ -357,21 +357,21 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_metric_with_ingestion_stats.period_filter
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Time: ingestion_metrics.period_filter
+      Log Type: ingestion_metrics.log_type
     row: 0
     col: 7
     width: 5
     height: 3
   - title: Total Error Count
     name: Total Error Count
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: single_value
-    fields: [ingestion_metric_with_ingestion_stats.total_error_events, ingestion_metric_with_ingestion_stats.period]
-    sorts: [ingestion_metric_with_ingestion_stats.period desc]
+    fields: [ingestion_metrics.total_error_events, ingestion_metrics.period]
+    sorts: [ingestion_metrics.period desc]
     limit: 500
-    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metric_with_ingestion_stats.total_error_events}
-          - offset(${ingestion_metric_with_ingestion_stats.total_error_events}, 1)', value_format: "#,##0.0,\" K\";-#,##0.0,\" K\"",
+    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metrics.total_error_events}
+          - offset(${ingestion_metrics.total_error_events}, 1)', value_format: "#,##0.0,\" K\";-#,##0.0,\" K\"",
         value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
     custom_color_enabled: true
@@ -414,8 +414,8 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_metric_with_ingestion_stats.period_filter
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Time: ingestion_metrics.period_filter
+      Log Type: ingestion_metrics.log_type
     row: 0
     col: 19
     width: 5
@@ -440,10 +440,10 @@
     height: 3
   - title: Recently Ingested Events
     name: Recently Ingested Events
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_grid
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.timestamp_time]
-    sorts: [ingestion_metric_with_ingestion_stats.timestamp_time desc]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.timestamp_time]
+    sorts: [ingestion_metrics.timestamp_time desc]
     limit: 100
     query_timezone: America/Los_Angeles
     show_view_names: false
@@ -465,8 +465,8 @@
     show_totals: true
     show_row_totals: true
     series_labels:
-      ingestion_metric_with_ingestion_stats.log_type: Log Type
-      ingestion_metric_with_ingestion_stats.timestamp_time: Timestamp
+      ingestion_metrics.log_type: Log Type
+      ingestion_metrics.timestamp_time: Timestamp
     limit_displayed_rows_values:
       show_hide: show
       first_last: first
@@ -500,22 +500,22 @@
     defaults_version: 1
     series_types: {}
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 24
     col: 0
     width: 12
     height: 6
   - title: Ingestion - Events by Status
     name: Ingestion - Events by Status
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_line
-    fields: [ingestion_metric_with_ingestion_stats.total_events, ingestion_metric_with_ingestion_stats.total_normalized_events,
-      ingestion_metric_with_ingestion_stats.total_error_events, ingestion_metric_with_ingestion_stats.total_parsing_error_events,
-      ingestion_metric_with_ingestion_stats.total_validation_error_events, ingestion_metric_with_ingestion_stats.timestamp_date]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_date]
+    fields: [ingestion_metrics.total_events, ingestion_metrics.total_normalized_events,
+      ingestion_metrics.total_error_events, ingestion_metrics.total_parsing_error_events,
+      ingestion_metrics.total_validation_error_events, ingestion_metrics.timestamp_date]
+    fill_fields: [ingestion_metrics.timestamp_date]
     filters:
-      ingestion_metric_with_ingestion_stats.period: This Period
-    sorts: [ingestion_metric_with_ingestion_stats.timestamp_date desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.timestamp_date desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -544,22 +544,22 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Time: ingestion_metric_with_ingestion_stats.period_filter
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Time: ingestion_metrics.period_filter
+      Log Type: ingestion_metrics.log_type
     row: 9
     col: 0
     width: 24
     height: 7
   - title: Ingestion - Events by Log Type
     name: Ingestion - Events by Log Type
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_grid
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.total_size_bytes, ingestion_metric_with_ingestion_stats.total_events,
-      ingestion_metric_with_ingestion_stats.total_normalized_events, ingestion_metric_with_ingestion_stats.total_error_events,
-      ingestion_metric_with_ingestion_stats.total_parsing_error_events, ingestion_metric_with_ingestion_stats.total_validation_error_events]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.total_events,
+      ingestion_metrics.total_normalized_events, ingestion_metrics.total_error_events,
+      ingestion_metrics.total_parsing_error_events, ingestion_metrics.total_validation_error_events]
     filters:
-      ingestion_metric_with_ingestion_stats.period: This Period
-    sorts: [ingestion_metric_with_ingestion_stats.total_size_bytes desc]
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.total_size_bytes desc]
     limit: 100
     query_timezone: America/Los_Angeles
     show_view_names: false
@@ -581,15 +581,15 @@
     show_totals: true
     show_row_totals: true
     series_labels:
-      ingestion_metric_with_ingestion_stats.log_type: Log Type
-      ingestion_metric_with_ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_metric_with_ingestion_stats.total_events: Ingested Events
-      ingestion_metric_with_ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_metric_with_ingestion_stats.total_error_events: Errors
-      ingestion_metric_with_ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_metric_with_ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Log Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     series_cell_visualizations:
-      ingestion_metric_with_ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     limit_displayed_rows_values:
       show_hide: show
@@ -620,22 +620,22 @@
     defaults_version: 1
     series_types: {}
     listen:
-      Time: ingestion_metric_with_ingestion_stats.period_filter
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Time: ingestion_metrics.period_filter
+      Log Type: ingestion_metrics.log_type
     row: 16
     col: 0
     width: 24
     height: 6
   - title: Ingestion - Throughput Hourly
     name: Ingestion - Throughput Hourly
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.total_size_bytes, ingestion_metric_with_ingestion_stats.timestamp_hour]
-    pivots: [ingestion_metric_with_ingestion_stats.log_type]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_hour]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.timestamp_hour]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_hour]
     filters:
-      ingestion_metric_with_ingestion_stats.timestamp_hour: 24 hours
-    sorts: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.timestamp_hour desc]
+      ingestion_metrics.timestamp_hour: 24 hours
+    sorts: [ingestion_metrics.log_type, ingestion_metrics.timestamp_hour desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -671,40 +671,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_metric_with_ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_metric_with_ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: UDM - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -714,13 +714,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_metric_with_ingestion_stats.log_type: Data Type
-      ingestion_metric_with_ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_metric_with_ingestion_stats.total_events: Ingested Events
-      ingestion_metric_with_ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_metric_with_ingestion_stats.total_error_events: Errors
-      ingestion_metric_with_ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_metric_with_ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -729,7 +729,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_metric_with_ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -742,21 +742,21 @@
     hide_totals: false
     hide_row_totals: false
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 36
     col: 0
     width: 24
     height: 7
   - title: Ingestion - Throughput Weekly
     name: Ingestion - Throughput Weekly
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_metric_with_ingestion_stats.timestamp_week, ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.total_size_bytes]
-    pivots: [ingestion_metric_with_ingestion_stats.log_type]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_week]
+    fields: [ingestion_metrics.timestamp_week, ingestion_metrics.log_type, ingestion_metrics.total_size_bytes]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_week]
     filters:
-      ingestion_metric_with_ingestion_stats.timestamp_time: 7 weeks
-    sorts: [ingestion_metric_with_ingestion_stats.timestamp_week desc, ingestion_metric_with_ingestion_stats.log_type]
+      ingestion_metrics.timestamp_time: 7 weeks
+    sorts: [ingestion_metrics.timestamp_week desc, ingestion_metrics.log_type]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -792,40 +792,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_metric_with_ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_metric_with_ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: UDM - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -835,13 +835,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_metric_with_ingestion_stats.log_type: Data Type
-      ingestion_metric_with_ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_metric_with_ingestion_stats.total_events: Ingested Events
-      ingestion_metric_with_ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_metric_with_ingestion_stats.total_error_events: Errors
-      ingestion_metric_with_ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_metric_with_ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -850,7 +850,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_metric_with_ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -863,21 +863,21 @@
     hide_totals: false
     hide_row_totals: false
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 43
     col: 0
     width: 24
     height: 7
   - title: Ingestion - Throughput(Last 6 Months)
     name: Ingestion - Throughput(Last 6 Months)
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.total_size_bytes, ingestion_metric_with_ingestion_stats.timestamp_month]
-    pivots: [ingestion_metric_with_ingestion_stats.log_type]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_month]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.timestamp_month]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_month]
     filters:
-      ingestion_metric_with_ingestion_stats.timestamp_month: 6 months
-    sorts: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.timestamp_month desc]
+      ingestion_metrics.timestamp_month: 6 months
+    sorts: [ingestion_metrics.log_type, ingestion_metrics.timestamp_month desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -913,40 +913,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_metric_with_ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_metric_with_ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: UDM - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -956,13 +956,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_metric_with_ingestion_stats.log_type: Data Type
-      ingestion_metric_with_ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_metric_with_ingestion_stats.total_events: Ingested Events
-      ingestion_metric_with_ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_metric_with_ingestion_stats.total_error_events: Errors
-      ingestion_metric_with_ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_metric_with_ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -971,7 +971,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_metric_with_ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -984,19 +984,19 @@
     hide_totals: false
     hide_row_totals: false
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 50
     col: 0
     width: 24
     height: 7
   - title: Ingestion - Throughput(All Time)
     name: Ingestion - Throughput(All Time)
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     type: looker_area
-    fields: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.total_size_bytes, ingestion_metric_with_ingestion_stats.timestamp_year]
-    pivots: [ingestion_metric_with_ingestion_stats.log_type]
-    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_year]
-    sorts: [ingestion_metric_with_ingestion_stats.log_type, ingestion_metric_with_ingestion_stats.timestamp_year desc]
+    fields: [ingestion_metrics.log_type, ingestion_metrics.total_size_bytes, ingestion_metrics.timestamp_year]
+    pivots: [ingestion_metrics.log_type]
+    fill_fields: [ingestion_metrics.timestamp_year]
+    sorts: [ingestion_metrics.log_type, ingestion_metrics.timestamp_year desc]
     limit: 500
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
@@ -1032,40 +1032,40 @@
       options:
         steps: 5
     y_axes: [{label: Throughput %, orientation: left, series: [{axisId: ASSET_STATIC_IP
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: CORELIGHT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: CORELIGHT}, {
-            axisId: ELASTIC_PACKETBEATS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_PACKETBEATS
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: FORWARDER_HEARTBEAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: FORWARDER_HEARTBEAT},
-          {axisId: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_CLOUD_NAT - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_CLOUD_NAT},
-          {axisId: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_CSCC - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_DNS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GCP_FIREWALL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: GCP_VPC_FLOW - ingestion_metric_with_ingestion_stats.total_size_bytes, name: GCP_VPC_FLOW},
-          {axisId: GMAIL_LOGS - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GMAIL_LOGS -
-              ingestion_metric_with_ingestion_stats.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: GSUITE_AUDIT - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: LINUX_OS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: POWERSHELL - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: SNORT_IDS - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SNORT_IDS}, {
-            axisId: SQUID_WEBPROXY - ingestion_metric_with_ingestion_stats.total_size_bytes, id: SQUID_WEBPROXY
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: UDM - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: UDM}, {axisId: WAZUH - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WAZUH
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
-              - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINDOWS_AD - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes,
-            id: WINDOWS_SYSMON - ingestion_metric_with_ingestion_stats.total_size_bytes, name: WINDOWS_SYSMON},
-          {axisId: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes, id: WINEVTLOG - ingestion_metric_with_ingestion_stats.total_size_bytes,
+              - ingestion_metrics.total_size_bytes, id: ASSET_STATIC_IP - ingestion_metrics.total_size_bytes,
+            name: ASSET_STATIC_IP}, {axisId: CORELIGHT - ingestion_metrics.total_size_bytes,
+            id: CORELIGHT - ingestion_metrics.total_size_bytes, name: CORELIGHT}, {
+            axisId: ELASTIC_PACKETBEATS - ingestion_metrics.total_size_bytes, id: ELASTIC_PACKETBEATS
+              - ingestion_metrics.total_size_bytes, name: ELASTIC_PACKETBEATS}, {axisId: ELASTIC_WINLOGBEAT
+              - ingestion_metrics.total_size_bytes, id: ELASTIC_WINLOGBEAT - ingestion_metrics.total_size_bytes,
+            name: ELASTIC_WINLOGBEAT}, {axisId: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes,
+            id: FORWARDER_HEARTBEAT - ingestion_metrics.total_size_bytes, name: FORWARDER_HEARTBEAT},
+          {axisId: GCP - ingestion_metrics.total_size_bytes, id: GCP - ingestion_metrics.total_size_bytes,
+            name: GCP}, {axisId: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes,
+            id: GCP_CLOUD_NAT - ingestion_metrics.total_size_bytes, name: GCP_CLOUD_NAT},
+          {axisId: GCP_CSCC - ingestion_metrics.total_size_bytes, id: GCP_CSCC - ingestion_metrics.total_size_bytes,
+            name: GCP_CSCC}, {axisId: GCP_DNS - ingestion_metrics.total_size_bytes,
+            id: GCP_DNS - ingestion_metrics.total_size_bytes, name: GCP_DNS}, {axisId: GCP_FIREWALL
+              - ingestion_metrics.total_size_bytes, id: GCP_FIREWALL - ingestion_metrics.total_size_bytes,
+            name: GCP_FIREWALL}, {axisId: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes,
+            id: GCP_VPC_FLOW - ingestion_metrics.total_size_bytes, name: GCP_VPC_FLOW},
+          {axisId: GMAIL_LOGS - ingestion_metrics.total_size_bytes, id: GMAIL_LOGS -
+              ingestion_metrics.total_size_bytes, name: GMAIL_LOGS}, {axisId: GSUITE_AUDIT
+              - ingestion_metrics.total_size_bytes, id: GSUITE_AUDIT - ingestion_metrics.total_size_bytes,
+            name: GSUITE_AUDIT}, {axisId: LINUX_OS - ingestion_metrics.total_size_bytes,
+            id: LINUX_OS - ingestion_metrics.total_size_bytes, name: LINUX_OS}, {axisId: POWERSHELL
+              - ingestion_metrics.total_size_bytes, id: POWERSHELL - ingestion_metrics.total_size_bytes,
+            name: POWERSHELL}, {axisId: SNORT_IDS - ingestion_metrics.total_size_bytes,
+            id: SNORT_IDS - ingestion_metrics.total_size_bytes, name: SNORT_IDS}, {
+            axisId: SQUID_WEBPROXY - ingestion_metrics.total_size_bytes, id: SQUID_WEBPROXY
+              - ingestion_metrics.total_size_bytes, name: SQUID_WEBPROXY}, {axisId: UDM
+              - ingestion_metrics.total_size_bytes, id: UDM - ingestion_metrics.total_size_bytes,
+            name: UDM}, {axisId: WAZUH - ingestion_metrics.total_size_bytes, id: WAZUH
+              - ingestion_metrics.total_size_bytes, name: WAZUH}, {axisId: WINDOWS_AD
+              - ingestion_metrics.total_size_bytes, id: WINDOWS_AD - ingestion_metrics.total_size_bytes,
+            name: WINDOWS_AD}, {axisId: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes,
+            id: WINDOWS_SYSMON - ingestion_metrics.total_size_bytes, name: WINDOWS_SYSMON},
+          {axisId: WINEVTLOG - ingestion_metrics.total_size_bytes, id: WINEVTLOG - ingestion_metrics.total_size_bytes,
             name: WINEVTLOG}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     limit_displayed_rows_values:
@@ -1075,13 +1075,13 @@
     series_types: {}
     series_colors: {}
     series_labels:
-      ingestion_metric_with_ingestion_stats.log_type: Data Type
-      ingestion_metric_with_ingestion_stats.total_size_bytes: Ingested Throughput
-      ingestion_metric_with_ingestion_stats.total_events: Ingested Events
-      ingestion_metric_with_ingestion_stats.total_normalized_events: Normalized Events
-      ingestion_metric_with_ingestion_stats.total_error_events: Errors
-      ingestion_metric_with_ingestion_stats.total_parsing_error_events: Parsing Errors
-      ingestion_metric_with_ingestion_stats.total_validation_error_events: Validation Errors
+      ingestion_metrics.log_type: Data Type
+      ingestion_metrics.total_size_bytes: Ingested Throughput
+      ingestion_metrics.total_events: Ingested Events
+      ingestion_metrics.total_normalized_events: Normalized Events
+      ingestion_metrics.total_error_events: Errors
+      ingestion_metrics.total_parsing_error_events: Parsing Errors
+      ingestion_metrics.total_validation_error_events: Validation Errors
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
@@ -1090,7 +1090,7 @@
     truncate_text: true
     size_to_fit: true
     series_cell_visualizations:
-      ingestion_metric_with_ingestion_stats.total_events:
+      ingestion_metrics.total_events:
         is_active: true
     table_theme: unstyled
     enable_conditional_formatting: false
@@ -1103,7 +1103,7 @@
     hide_totals: false
     hide_row_totals: false
     listen:
-      Log Type: ingestion_metric_with_ingestion_stats.log_type
+      Log Type: ingestion_metrics.log_type
     row: 57
     col: 0
     width: 24
@@ -1129,9 +1129,9 @@
       type: advanced
       display: popover
       options: []
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     listens_to_filters: []
-    field: ingestion_metric_with_ingestion_stats.period_filter
+    field: ingestion_metrics.period_filter
   - name: Log Type
     title: Log Type
     type: field_filter
@@ -1142,6 +1142,6 @@
       type: advanced
       display: popover
       options: []
-    explore: ingestion_metric_with_ingestion_stats
+    explore: ingestion_metrics
     listens_to_filters: []
-    field: ingestion_metric_with_ingestion_stats.log_type
+    field: ingestion_metrics.log_type

--- a/dashboards/main.dashboard.lookml
+++ b/dashboards/main.dashboard.lookml
@@ -39,7 +39,7 @@
     limit: 500
     dynamic_fields: [{table_calculation: delta, label: Delta, expression: '(${rule_detections.count_for_drill}
           - offset(${rule_detections.count_for_drill}, 1))', value_format: "#,##0;-#,##0",
-          value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
+        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
     custom_color_enabled: true
     show_single_value_title: false
@@ -88,21 +88,17 @@
     height: 3
   - title: Ingestion Data Size
     name: Ingestion Data Size
-    explore: ingestion_metrics
+    explore: ingestion_metric_with_ingestion_stats
     type: single_value
-    fields: [ingestion_metrics.total_size_bytes, ingestion_metrics.period]
+    fields: [ingestion_metric_with_ingestion_stats.total_size_bytes, ingestion_metric_with_ingestion_stats.period]
     filters:
-      ingestion_metrics.log_type: -"FORWARDER_HEARTBEAT"
-    sorts: [ingestion_metrics.period desc]
+      ingestion_metric_with_ingestion_stats.log_type: -"FORWARDER_HEARTBEAT"
+    sorts: [ingestion_metric_with_ingestion_stats.period desc]
     limit: 500
-    dynamic_fields: [{table_calculation: size_gb, label: Size (GB), expression: " round(${ingestion_metrics.total_size_bytes}/1000/1000/1000,\
-          \ 2)", value_format: !!null '', value_format_name: !!null '', is_disabled: true,
-          _kind_hint: dimension, _type_hint: number}, {table_calculation: delta, label: Delta,
-          expression: '${ingestion_metrics.total_size_bytes} - offset(${ingestion_metrics.total_size_bytes},1)',
-          value_format: "#,##0.0,,,\" GB\";-#,##0.0,,,\" GB\"", value_format_name: !!null '', is_disabled: false,
-          _kind_hint: measure, _type_hint: number}, {measure: sum_of_size_bytes, based_on: ingestion_metrics.size_bytes,
-          type: sum, label: Sum of Size Bytes, expression: !!null '', _kind_hint: measure,
-          _type_hint: number}]
+    dynamic_fields: [{category: table_calculation, expression: "${ingestion_metric_with_ingestion_stats.total_size_bytes}\
+          \ - offset(${ingestion_metric_with_ingestion_stats.total_size_bytes},1)",
+        label: Delta, value_format: '#,##0.0,,," GB";-#,##0.0,,," GB"', value_format_name: !!null '',
+        _kind_hint: measure, table_calculation: delta, _type_hint: number}]
     query_timezone: America/Los_Angeles
     custom_color_enabled: true
     show_single_value_title: false
@@ -165,26 +161,24 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_metrics.period_filter
+      Time: ingestion_metric_with_ingestion_stats.period_filter
     row: 3
     col: 7
     width: 9
     height: 3
   - title: Events Over Time
     name: Events Over Time
-    explore: ingestion_metrics
+    explore: ingestion_metric_with_ingestion_stats
     type: looker_column
-    fields: [total_events_count, ingestion_metrics.timestamp_date, ingestion_metrics.log_type_for_drill]
-    pivots: [ingestion_metrics.log_type_for_drill]
-    fill_fields: [ingestion_metrics.timestamp_date]
+    fields: [ingestion_metric_with_ingestion_stats.total_entry_number, ingestion_metric_with_ingestion_stats.timestamp_date,
+      ingestion_metric_with_ingestion_stats.log_type_for_drill]
+    pivots: [ingestion_metric_with_ingestion_stats.log_type_for_drill]
+    fill_fields: [ingestion_metric_with_ingestion_stats.timestamp_date]
     filters:
-      ingestion_metrics.log_type_for_drill: -"FORWARDER_HEARTBEAT",-NULL
-      ingestion_metrics.period: This Period
-    sorts: [ingestion_metrics.timestamp_date desc, ingestion_metrics.log_type_for_drill]
+      ingestion_metric_with_ingestion_stats.log_type_for_drill: -"FORWARDER_HEARTBEAT",-NULL
+      ingestion_metric_with_ingestion_stats.period: This Period
+    sorts: [ingestion_metric_with_ingestion_stats.timestamp_date desc, ingestion_metric_with_ingestion_stats.log_type_for_drill]
     limit: 500
-    dynamic_fields: [{measure: total_events_count, based_on: ingestion_metrics.entry_number,
-        type: sum, label: Total Events Count, expression: !!null '', value_format: !!null '',
-        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
     x_axis_gridlines: false
     y_axis_gridlines: true
@@ -225,72 +219,22 @@
     note_display: hover
     note_text: Trends for volume of different event types ingested by Chronicle
     listen:
-      Time: ingestion_metrics.period_filter
+      Time: ingestion_metric_with_ingestion_stats.period_filter
     row: 7
     col: 0
     width: 10
     height: 9
-  - title: Global Threat Map - IOC IP Matches
-    name: Global Threat Map - IOC IP Matches
-    explore: global_threat_map_ioc
-    type: looker_map
-    fields: [global_threat_map_ioc.ioc_matches_test_ioc_value, global_threat_map_ioc.location,
-      global_threat_map_ioc.count]
-    filters:
-      global_threat_map_ioc.ioc_matches_test_ioc_value: "-NULL"
-    sorts: [global_threat_map_ioc.count desc]
-    limit: 5000
-    query_timezone: America/Los_Angeles
-    map_plot_mode: points
-    heatmap_gridlines: false
-    heatmap_gridlines_empty: false
-    heatmap_opacity: 0.5
-    show_region_field: true
-    draw_map_labels_above_data: true
-    map_tile_provider: light
-    map_position: fit_data
-    map_scale_indicator: 'off'
-    map_pannable: true
-    map_zoomable: true
-    map_marker_type: circle
-    map_marker_icon_name: default
-    map_marker_radius_mode: proportional_value
-    map_marker_units: pixels
-    map_marker_proportional_scale_type: linear
-    map_marker_color_mode: fixed
-    show_view_names: false
-    show_legend: true
-    quantize_map_value_colors: false
-    reverse_map_value_colors: false
-    map_latitude: 18.646245142670608
-    map_longitude: 4.921875000000001
-    map_zoom: 1
-    map_marker_radius_fixed: 3
-    map_marker_radius_max: 20
-    map_marker_color: [red]
-    defaults_version: 1
-    note_state: collapsed
-    note_display: hover
-    note_text: Geo-location of the IP addresses of IOC matches, put on a Global Map
-    listen:
-      Time: global_threat_map_ioc.period_filter
-    row: 7
-    col: 10
-    width: 14
-    height: 9
   - title: Events for Main Dashboard
     name: Events for Main Dashboard
-    explore: ingestion_metrics
+    explore: ingestion_metric_with_ingestion_stats
     type: single_value
-    fields: [ingestion_metrics.total_entry_number, ingestion_metrics.period]
-    filters:
-      ingestion_metrics.log_type: -"FORWARDER_HEARTBEAT"
-    sorts: [ingestion_metrics.period desc]
+    fields: [ingestion_metric_with_ingestion_stats.total_entry_number, ingestion_metric_with_ingestion_stats.period]
+    sorts: [ingestion_metric_with_ingestion_stats.period desc]
     limit: 500
-    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metrics.total_entry_number}
-        - offset(${ingestion_metrics.total_entry_number}, 1)',
-        value_format: "#,##0,\" K\";-#,##0,\" K\"", value_format_name: !!null '', _kind_hint: measure,
-        _type_hint: number}]
+    column_limit: 50
+    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metric_with_ingestion_stats.total_entry_number}
+          - offset(${ingestion_metric_with_ingestion_stats.total_entry_number}, 1)', value_format: "#,##0,\" K\";-#,##0,\" K\"",
+        value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
     custom_color_enabled: true
     show_single_value_title: false
@@ -332,11 +276,82 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_metrics.period_filter
+      Time: ingestion_metric_with_ingestion_stats.period_filter
     row: 3
     col: 0
     width: 7
     height: 3
+  - title: Global Threat Map - IOC IP Matches
+    name: Global Threat Map - IOC IP Matches
+    explore: ioc_matches
+    type: looker_map
+    fields: [ioc_matches.ioc_value, ioc_matches.count, ioc_matches.ioc_location]
+    filters:
+      ioc_matches.ioc_type: '"IOC_TYPE_IP"'
+    sorts: [ioc_matches.count desc]
+    limit: 5000
+    map_plot_mode: points
+    heatmap_gridlines: false
+    heatmap_gridlines_empty: false
+    heatmap_opacity: 0.5
+    show_region_field: true
+    draw_map_labels_above_data: true
+    map_tile_provider: light
+    map_position: fit_data
+    map_scale_indicator: 'off'
+    map_pannable: true
+    map_zoomable: true
+    map_marker_type: circle
+    map_marker_icon_name: default
+    map_marker_radius_mode: proportional_value
+    map_marker_units: pixels
+    map_marker_proportional_scale_type: linear
+    map_marker_color_mode: fixed
+    show_view_names: false
+    show_legend: true
+    quantize_map_value_colors: false
+    reverse_map_value_colors: false
+    map_latitude: 34.28116438134217
+    map_longitude: -65.88741302490236
+    map_zoom: 3
+    map_marker_color: [red]
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    defaults_version: 1
+    series_types: {}
+    note_state: collapsed
+    note_display: hover
+    note_text: Geo-location of the IP addresses of IOC matches, put on a Global Map
+    listen:
+      Time: ioc_matches.event_timestamp_date
+    row: 5
+    col: 10
+    width: 14
+    height: 9
   filters:
   - name: Time
     title: Time
@@ -347,6 +362,6 @@
     ui_config:
       type: advanced
       display: popover
-    explore: ingestion_metrics
+    explore: ingestion_stats
     listens_to_filters: []
-    field: ingestion_metrics.period_filter
+    field: ingestion_stats.period_filter

--- a/dashboards/main.dashboard.lookml
+++ b/dashboards/main.dashboard.lookml
@@ -88,19 +88,19 @@
     height: 3
   - title: Ingestion Data Size
     name: Ingestion Data Size
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: single_value
-    fields: [ingestion_stats.total_size_bytes, ingestion_stats.period]
+    fields: [ingestion_metrics.total_size_bytes, ingestion_metrics.period]
     filters:
-      ingestion_stats.log_type: -"FORWARDER_HEARTBEAT"
-    sorts: [ingestion_stats.period desc]
+      ingestion_metrics.log_type: -"FORWARDER_HEARTBEAT"
+    sorts: [ingestion_metrics.period desc]
     limit: 500
-    dynamic_fields: [{table_calculation: size_gb, label: Size (GB), expression: " round(${ingestion_stats.total_size_bytes}/1000/1000/1000,\
+    dynamic_fields: [{table_calculation: size_gb, label: Size (GB), expression: " round(${ingestion_metrics.total_size_bytes}/1000/1000/1000,\
           \ 2)", value_format: !!null '', value_format_name: !!null '', is_disabled: true,
           _kind_hint: dimension, _type_hint: number}, {table_calculation: delta, label: Delta,
-          expression: '${ingestion_stats.total_size_bytes} - offset(${ingestion_stats.total_size_bytes},1)',
+          expression: '${ingestion_metrics.total_size_bytes} - offset(${ingestion_metrics.total_size_bytes},1)',
           value_format: "#,##0.0,,,\" GB\";-#,##0.0,,,\" GB\"", value_format_name: !!null '', is_disabled: false,
-          _kind_hint: measure, _type_hint: number}, {measure: sum_of_size_bytes, based_on: ingestion_stats.size_bytes,
+          _kind_hint: measure, _type_hint: number}, {measure: sum_of_size_bytes, based_on: ingestion_metrics.size_bytes,
           type: sum, label: Sum of Size Bytes, expression: !!null '', _kind_hint: measure,
           _type_hint: number}]
     query_timezone: America/Los_Angeles
@@ -165,24 +165,24 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 3
     col: 7
     width: 9
     height: 3
   - title: Events Over Time
     name: Events Over Time
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: looker_column
-    fields: [total_events_count, ingestion_stats.timestamp_date, ingestion_stats.log_type_for_drill]
-    pivots: [ingestion_stats.log_type_for_drill]
-    fill_fields: [ingestion_stats.timestamp_date]
+    fields: [total_events_count, ingestion_metrics.timestamp_date, ingestion_metrics.log_type_for_drill]
+    pivots: [ingestion_metrics.log_type_for_drill]
+    fill_fields: [ingestion_metrics.timestamp_date]
     filters:
-      ingestion_stats.log_type_for_drill: -"FORWARDER_HEARTBEAT",-NULL
-      ingestion_stats.period: This Period
-    sorts: [ingestion_stats.timestamp_date desc, ingestion_stats.log_type_for_drill]
+      ingestion_metrics.log_type_for_drill: -"FORWARDER_HEARTBEAT",-NULL
+      ingestion_metrics.period: This Period
+    sorts: [ingestion_metrics.timestamp_date desc, ingestion_metrics.log_type_for_drill]
     limit: 500
-    dynamic_fields: [{measure: total_events_count, based_on: ingestion_stats.entry_number,
+    dynamic_fields: [{measure: total_events_count, based_on: ingestion_metrics.entry_number,
         type: sum, label: Total Events Count, expression: !!null '', value_format: !!null '',
         value_format_name: !!null '', _kind_hint: measure, _type_hint: number}]
     query_timezone: America/Los_Angeles
@@ -225,7 +225,7 @@
     note_display: hover
     note_text: Trends for volume of different event types ingested by Chronicle
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 7
     col: 0
     width: 10
@@ -280,15 +280,15 @@
     height: 9
   - title: Events for Main Dashboard
     name: Events for Main Dashboard
-    explore: ingestion_stats
+    explore: ingestion_metrics
     type: single_value
-    fields: [ingestion_stats.total_entry_number, ingestion_stats.period]
+    fields: [ingestion_metrics.total_entry_number, ingestion_metrics.period]
     filters:
-      ingestion_stats.log_type: -"FORWARDER_HEARTBEAT"
-    sorts: [ingestion_stats.period desc]
+      ingestion_metrics.log_type: -"FORWARDER_HEARTBEAT"
+    sorts: [ingestion_metrics.period desc]
     limit: 500
-    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_stats.total_entry_number}
-        - offset(${ingestion_stats.total_entry_number}, 1)',
+    dynamic_fields: [{table_calculation: delta, label: Delta, expression: '${ingestion_metrics.total_entry_number}
+        - offset(${ingestion_metrics.total_entry_number}, 1)',
         value_format: "#,##0,\" K\";-#,##0,\" K\"", value_format_name: !!null '', _kind_hint: measure,
         _type_hint: number}]
     query_timezone: America/Los_Angeles
@@ -332,7 +332,7 @@
     note_display: hover
     note_text: Delta compared to previous time period
     listen:
-      Time: ingestion_stats.period_filter
+      Time: ingestion_metrics.period_filter
     row: 3
     col: 0
     width: 7
@@ -347,6 +347,6 @@
     ui_config:
       type: advanced
       display: popover
-    explore: ingestion_stats
+    explore: ingestion_metrics
     listens_to_filters: []
-    field: ingestion_stats.period_filter
+    field: ingestion_metrics.period_filter

--- a/dashboards/user_signin_overview.dashboard.lookml
+++ b/dashboards/user_signin_overview.dashboard.lookml
@@ -9,7 +9,7 @@
     type: looker_pie
     fields: [udm_events_aggregates.action, udm_events_aggregates.count]
     sorts: [udm_events_aggregates.count desc]
-    limit: 500
+    limit: 50
     value_labels: legend
     label_type: val
     inner_radius: 60
@@ -456,11 +456,10 @@
     height: 6
   - title: Sign In Location Map
     name: Sign In Location Map
-    explore: user_login_source_geo_ip
+    explore: udm_events_aggregates
     type: looker_map
-    fields: [user_login_source_geo_ip.principal_ip, user_login_source_geo_ip.location,
-      user_login_source_geo_ip.count]
-    sorts: [user_login_source_geo_ip.count desc]
+    fields: [udm_events_aggregates.count, udm_events_aggregates.principal_ip, udm_events_aggregates.principal_location__location]
+    sorts: [udm_events_aggregates.count desc]
     limit: 5000
     map_plot_mode: points
     heatmap_gridlines: false
@@ -489,7 +488,7 @@
     map_marker_radius_max: 20
     defaults_version: 1
     listen:
-      Time: user_login_source_geo_ip.time_filter
+      Time: udm_events_aggregates.event_hour_time
     row: 21
     col: 8
     width: 7
@@ -578,12 +577,12 @@
     height: 7
   - title: Sign Ins by Country
     name: Sign Ins by Country
-    explore: user_login_source_geo_ip
+    explore: udm_events_aggregates
     type: looker_bar
-    fields: [user_login_source_geo_ip.count, user_login_source_geo_ip.country_label]
+    fields: [udm_events_aggregates.principal_location__country_or_region, udm_events_aggregates.count]
     filters:
-      user_login_source_geo_ip.country_label: "-NULL"
-    sorts: [user_login_source_geo_ip.count desc 0, user_login_source_geo_ip.country_label]
+      udm_events_aggregates.principal_location__country_or_region: "-NULL"
+    sorts: [udm_events_aggregates.count desc, udm_events_aggregates.principal_location__country_or_region]
     limit: 5000
     x_axis_gridlines: false
     y_axis_gridlines: true
@@ -612,51 +611,27 @@
     show_totals_labels: false
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: Events Count, orientation: bottom, series: [{axisId: user_login_source_geo_ip.count,
-            id: user_login_source_geo_ip.count, name: User Login Source Geo IP}],
+    y_axes: [{label: Events Count, orientation: bottom, series: [{axisId: udm_events_aggregates.count,
+            id: udm_events_aggregates.count, name: Udm Events Aggregates}],
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         tickDensityCustom: 5, type: linear}]
     x_axis_label: Country
     series_types: {}
-    map_plot_mode: points
-    heatmap_gridlines: false
-    heatmap_gridlines_empty: false
-    heatmap_opacity: 0.5
-    show_region_field: true
-    draw_map_labels_above_data: true
-    map_tile_provider: dark
-    map_position: fit_data
-    map_scale_indicator: 'off'
-    map_pannable: true
-    map_zoomable: true
-    map_marker_type: circle
-    map_marker_icon_name: default
-    map_marker_radius_mode: proportional_value
-    map_marker_units: pixels
-    map_marker_proportional_scale_type: linear
-    map_marker_color_mode: value
-    show_legend: true
-    quantize_map_value_colors: false
-    reverse_map_value_colors: false
-    map_latitude: 17.978733095556183
-    map_longitude: 6.50390625
-    map_zoom: 2
-    map_marker_radius_max: 20
     defaults_version: 1
     listen:
-      Time: user_login_source_geo_ip.time_filter
+      Time: udm_events_aggregates.event_hour_date
     row: 15
     col: 8
     width: 16
     height: 6
   - title: Top 10 Countries by Sign Ins
     name: Top 10 Countries by Sign Ins
-    explore: user_login_source_geo_ip
+    explore: udm_events_aggregates
     type: looker_pie
-    fields: [user_login_source_geo_ip.count, user_login_source_geo_ip.country_label]
+    fields: [udm_events_aggregates.count, udm_events_aggregates.principal_location__country_or_region]
     filters:
-      user_login_source_geo_ip.country_label: "-NULL"
-    sorts: [user_login_source_geo_ip.count desc 0, user_login_source_geo_ip.country_label]
+      udm_events_aggregates.principal_location__country_or_region: "-NULL"
+    sorts: [udm_events_aggregates.count desc, udm_events_aggregates.principal_location__country_or_region]
     limit: 10
     value_labels: legend
     label_type: labPer
@@ -694,34 +669,10 @@
     show_totals_labels: false
     show_silhouette: false
     totals_color: "#808080"
-    map_plot_mode: points
-    heatmap_gridlines: false
-    heatmap_gridlines_empty: false
-    heatmap_opacity: 0.5
-    show_region_field: true
-    draw_map_labels_above_data: true
-    map_tile_provider: dark
-    map_position: fit_data
-    map_scale_indicator: 'off'
-    map_pannable: true
-    map_zoomable: true
-    map_marker_type: circle
-    map_marker_icon_name: default
-    map_marker_radius_mode: proportional_value
-    map_marker_units: pixels
-    map_marker_proportional_scale_type: linear
-    map_marker_color_mode: value
-    show_legend: true
-    quantize_map_value_colors: false
-    reverse_map_value_colors: false
-    map_latitude: 17.978733095556183
-    map_longitude: 6.50390625
-    map_zoom: 2
-    map_marker_radius_max: 20
     defaults_version: 1
     series_types: {}
     listen:
-      Time: user_login_source_geo_ip.time_filter
+      Time: udm_events_aggregates.event_hour_date
     row: 15
     col: 0
     width: 8

--- a/explores/ingestion_metric_with_ingestion_stats.explore.lkml
+++ b/explores/ingestion_metric_with_ingestion_stats.explore.lkml
@@ -2,5 +2,5 @@ include: "/views/custom/ingestion_metric_with_ingestion_stats.view.lkml"
 
 explore: ingestion_metric_with_ingestion_stats {
   # extension: required
-  # hidden: yes
+  hidden: yes
 }

--- a/explores/ingestion_stats.explore.lkml
+++ b/explores/ingestion_stats.explore.lkml
@@ -5,4 +5,5 @@ include: "/views/refinements/ingestion_stats.view.lkml"
 explore: ingestion_stats {
   #view_name: ingestion_stats
   #extension: required
+  hidden: yes
 }

--- a/views/ingestion_metrics.view.lkml
+++ b/views/ingestion_metrics.view.lkml
@@ -61,9 +61,12 @@ view: ingestion_metrics {
       week,
       month,
       quarter,
+      hour,
+      minute,
       year
     ]
-    sql: ${TABLE}.end_time ;;
+    datatype: epoch
+    sql: UNIX_SECONDS(${TABLE}.end_time) ;;
   }
 
   dimension: error_code {
@@ -115,10 +118,10 @@ view: ingestion_metrics {
     sql: ${TABLE}.latency_overflow ;;
   }
 
-  dimension: latency_time_milliseconds {
-    type: number
-    sql: ${TABLE}.latency_time_milliseconds ;;
-  }
+  # dimension: latency_time_milliseconds {
+  #   type: number
+  #   sql: ${TABLE}.latency_time_milliseconds ;;
+  # }
 
   dimension: latency_underflow {
     type: number
@@ -145,10 +148,10 @@ view: ingestion_metrics {
     sql: ${TABLE}.namespace ;;
   }
 
-  dimension: normalization_state {
-    type: string
-    sql: ${TABLE}.normalization_state ;;
-  }
+  # dimension: normalization_state {
+  #   type: string
+  #   sql: ${TABLE}.normalization_state ;;
+  # }
 
   dimension: regex_filter {
     type: string
@@ -164,9 +167,12 @@ view: ingestion_metrics {
       week,
       month,
       quarter,
+      hour,
+      minute,
       year
     ]
-    sql: ${TABLE}.start_time ;;
+    datatype: epoch
+    sql: UNIX_SECONDS(${TABLE}.start_time) ;;
   }
 
   dimension: state {
@@ -174,9 +180,50 @@ view: ingestion_metrics {
     sql: ${TABLE}.state ;;
   }
 
+  dimension: quota_rejected_long_term_log_volume {
+    type: number
+    sql: ${TABLE}.quota_rejected_long_term_log_volume ;;
+  }
+
+  dimension: quota_limit_per_day {
+    type: number
+    sql: ${TABLE}.quota_limit_per_day ;;
+  }
+
+  dimension: quota_rejected_short_term_log_volume {
+    type: number
+    sql: ${TABLE}.quota_rejected_short_term_log_volume ;;
+  }
+
+  dimension: quota_limit_per_second {
+    type: number
+    sql: ${TABLE}.quota_limit_per_second ;;
+  }
+
   measure: count {
     type: count
     drill_fields: []
+  }
+
+  measure: last_heartbeat_max {
+    hidden: yes
+    type: date
+    sql: MAX(${last_heartbeat_raw}) ;;
+  }
+
+  measure: minutes_since_last_heartbeat {
+    type: number
+    sql:  (DATETIME_DIFF(CURRENT_DATETIME(), ${last_heartbeat_max}, minute)) * 1 ;;
+  }
+  
+  measure: min_start_time {
+    type: date_time
+    sql: min(TIMESTAMP_SECONDS(${start_raw}));;
+  }
+
+  measure: max_end_time {
+    type: date_time
+    sql: max(TIMESTAMP_SECONDS(${end_raw}));;
   }
 }
 

--- a/views/ingestion_stats.view.lkml
+++ b/views/ingestion_stats.view.lkml
@@ -3,6 +3,7 @@ view: ingestion_stats {
     ;;
 
   dimension_group: _partitiondate {
+    description: "Deprecated"
     type: time
     timeframes: [
       raw,
@@ -18,6 +19,7 @@ view: ingestion_stats {
   }
 
   dimension_group: _partitiontime {
+    description: "Deprecated"
     type: time
     timeframes: [
       raw,
@@ -33,16 +35,19 @@ view: ingestion_stats {
   }
 
   dimension: enrichment_error_count {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.enrichment_error_count ;;
   }
 
   dimension: enrichment_error_ratio {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.enrichment_error_ratio ;;
   }
 
   dimension: entry_number {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.entry_number ;;
   }
@@ -53,61 +58,73 @@ view: ingestion_stats {
   }
 
   dimension: normalization_ratio {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.normalization_ratio ;;
   }
 
   dimension: normalized_event_count {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.normalized_event_count ;;
   }
 
   dimension: parsing_error_count {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.parsing_error_count ;;
   }
 
   dimension: parsing_error_ratio {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.parsing_error_ratio ;;
   }
 
   dimension: size_bytes {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.size_bytes ;;
   }
 
   dimension: source {
+    description: "Deprecated"
     type: string
     sql: ${TABLE}.source ;;
   }
 
   dimension: time_bucket {
+    description: "Deprecated"
     type: string
     sql: ${TABLE}.time_bucket ;;
   }
 
   dimension: timestamp_sec {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.timestamp_sec ;;
   }
 
   dimension: total_error_count {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.total_error_count ;;
   }
 
   dimension: total_error_ratio {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.total_error_ratio ;;
   }
 
   dimension: validation_error_count {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.validation_error_count ;;
   }
 
   dimension: validation_error_ratio {
+    description: "Deprecated"
     type: number
     sql: ${TABLE}.validation_error_ratio ;;
   }

--- a/views/refinements/udm_events_aggregates.view.lkml
+++ b/views/refinements/udm_events_aggregates.view.lkml
@@ -10,4 +10,40 @@ view: +udm_events_aggregates {
       icon_url: "@{USER_PAGE_ICON_URL}"
     }
   }
+  dimension: principal_location__location {
+    type: location
+    sql_latitude: ${principal_location__region_latitude} ;;
+    sql_longitude: ${principal_location__region_longitude} ;;
+    group_label: "Principal Location"
+    group_item_label: "Location"
+  }
+
+  dimension: target_location__location {
+    type: location
+    sql_latitude: ${target_location__region_latitude} ;;
+    sql_longitude: ${target_location__region_longitude} ;;
+    group_label: "Target Location"
+    group_item_label: "Location"
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [detail*]
+  }
+
+  # ----- Sets of fields for drilling ------
+  set: detail {
+    fields: [
+      target_hostname,
+      principal_hostname,
+      principal_ip,
+      target_location__name,
+      principal_location__name,
+      target_location__desk_name,
+      target_location__floor_name,
+      principal_location__desk_name,
+      principal_location__floor_name,
+      count
+    ]
+  }
 }


### PR DESCRIPTION
https://screencast.googleplex.com/cast/NjQ5Nzk4MTAwNzEzNDcyMHw4MmZhYjgxYy04YQ
Default dashboards screencast

https://screenshot.googleplex.com/5rJZ57r94z5FkqX
Explores visible : Made no change to visibility but we arent showing aggregates explores from start so kept it as is.

Tested the updates for ingestion_stats and ingestion_metrics_with_ingestion_stats to move to ingestion_metrics.
Added some missing fields for aggregates as the default dashboard was broken
Removed usage of hidden custom explores from default dashboards